### PR TITLE
Implement naive async card image caching using HashMap and bool flag

### DIFF
--- a/app/src/main/java/com/spectralfergus/practice/tarotapp/Card.java
+++ b/app/src/main/java/com/spectralfergus/practice/tarotapp/Card.java
@@ -2,7 +2,9 @@ package com.spectralfergus.practice.tarotapp;
 
 import android.arch.persistence.room.ColumnInfo;
 import android.arch.persistence.room.Entity;
+import android.arch.persistence.room.Ignore;
 import android.arch.persistence.room.PrimaryKey;
+import android.graphics.drawable.Drawable;
 
 @Entity(tableName = "card_table")
 public class Card {
@@ -22,9 +24,10 @@ public class Card {
     @ColumnInfo(name = "meaning_rev")
     private String meaningRev;          // Imprudence, incapacity...
     private String desc;                // He is riding in full course, as if scattering his enemies...
+    private boolean hasImage;
 
     // Constructor allows room to re-create Card objects from database
-    public Card(String nameShort, String name, String value, int valueInt, String suit, String arcana, String meaningUp, String meaningRev, String desc) {
+    public Card(String nameShort, String name, String value, int valueInt, String suit, String arcana, String meaningUp, String meaningRev, String desc, boolean hasImage) {
         this.nameShort = nameShort;
         this.name = name;
         this.value = value;
@@ -34,6 +37,7 @@ public class Card {
         this.meaningUp = meaningUp;
         this.meaningRev = meaningRev;
         this.desc = desc;
+        this.hasImage = hasImage;
     }
 
     // == getters ==
@@ -77,6 +81,10 @@ public class Card {
         return desc;
     }
 
+    public boolean getHasImage() {
+        return hasImage;
+    }
+
     @Override
     public String toString() {
         return name;
@@ -86,6 +94,10 @@ public class Card {
     // Only value that does not appear in constructor, required for Room to interface with Card
     public void setId(int id) {
         this.id = id;
+    }
+
+    public void setHasImage(boolean hasImage) {
+        this.hasImage = hasImage;
     }
 }
 

--- a/app/src/main/java/com/spectralfergus/practice/tarotapp/CardDatabase.java
+++ b/app/src/main/java/com/spectralfergus/practice/tarotapp/CardDatabase.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-@Database(entities = {Card.class}, version = 2)
+@Database(entities = {Card.class}, version = 3)
 public abstract class CardDatabase extends RoomDatabase {
     private static CardDatabase instance;
 

--- a/app/src/main/java/com/spectralfergus/practice/tarotapp/CardViewModel.java
+++ b/app/src/main/java/com/spectralfergus/practice/tarotapp/CardViewModel.java
@@ -4,14 +4,17 @@ import android.app.Application;
 import android.arch.lifecycle.AndroidViewModel;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 
+import java.util.HashMap;
 import java.util.List;
 
 public class CardViewModel extends AndroidViewModel {
     private CardRepository repository;
     private LiveData<List<Card>> cardList;
     private MutableLiveData<Integer> iSelected;
+    private MutableLiveData<HashMap<String,Drawable>> cardImages;
 
     public CardViewModel(@NonNull Application application) {
         super(application);
@@ -27,28 +30,45 @@ public class CardViewModel extends AndroidViewModel {
     public void insert(Card c) {
         repository.insert(c);
     }
+
     public void update(Card c) {
         repository.update(c);
     }
+
     public void delete(Card c) {
         repository.delete(c);
     }
+
     public void deleteAllCards() {
         repository.deleteAllCards();
     }
+
     public void fetchRandomTarot(int n) {
         resetSelector();
-        repository.fetchRandomTarot(n);}
-    public void resetSelector() { iSelected.setValue(0);}
+        repository.fetchRandomTarot(n);
+    }
+
+    public void resetSelector() {
+        iSelected.setValue(0);
+    }
 
     public LiveData<List<Card>> getCardList() {
         return cardList;
     }
 
+    public void fetchCardImage(int position) {
+        repository.fetchCardImage(position);
+    }
+
     public LiveData<Integer> getISelected() {
         return iSelected;
     }
+
     public void setiSelected(int position) {
         iSelected.setValue(position);
+    }
+
+    public Drawable getCardImage(Card curCard) {
+        return repository.getCardImage(curCard);
     }
 }

--- a/app/src/main/java/com/spectralfergus/practice/tarotapp/MainActivity.java
+++ b/app/src/main/java/com/spectralfergus/practice/tarotapp/MainActivity.java
@@ -4,6 +4,7 @@ import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
@@ -18,6 +19,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements CardAdapter.ListItemOnClickListener {

--- a/app/src/main/java/com/spectralfergus/practice/tarotapp/utils/JsonUtils.java
+++ b/app/src/main/java/com/spectralfergus/practice/tarotapp/utils/JsonUtils.java
@@ -48,7 +48,8 @@ public class JsonUtils {
                 toTitleCase(card.getString("type")),
                 card.getString("meaning_up"),
                 card.getString("meaning_rev"),
-                card.getString("desc"));
+                card.getString("desc"),
+                false);
     }
 
     private static String toTitleCase(String s) {


### PR DESCRIPTION
Related to issue #26
The AsyncTask for fetching images from url was called n! times (where n is the number of cards in the list) every time a card was added, which is suuuuper inefficient.

Now, once fetched, images are stored in a static HashMap in the Repository based on the card's short name. For each additional call to fetch the image, the repository checks whether an image exists in the HashMap to decide if it needs to make the call over the network to fetch it. An extra boolean field was added to the Card object. Once flipped, it triggers the cardLists' onChanged() method, updating the UI with the right card images on bind.